### PR TITLE
Update supported protocols when ready

### DIFF
--- a/Supported-Protocols.md
+++ b/Supported-Protocols.md
@@ -5,25 +5,25 @@ PacketGen provides built-in packet parsers for the following protocols:
 ### Protocols
 | Protocol 	|       Status      	|
 |:--------:	|:-----------------:	|
-|    [ETH](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/Eth)   	|     ✔     	|
-|    [ARP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/ARP)   	|     ✔     	|
-|    [IP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/IP)    	  |     ✔     	|
-|    [IP6](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/IPv6)   	|     ✔     	|
-|    [TCP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/TCP)   	|     ✔     	|
-|    [UDP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/UDP)   	|     ✔     	|
-|   [ICMP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/ICMP)   	|     ✔     	|
-|   [ICMP6](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/ICMPv6) |     ✔     	|
-|    [DNS](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/DNS)   	|     ✔     	|
-|   [Dot11](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/Dot11)  |     ✔     	|
-|   [Dot1q](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/Dot1q)  |     ✔     	|
-|    [EAP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/EAP)   	|     ✔      	|
-|    [ESP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/ESP)   	|     ✔     	|
-|    [GRE](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/GRE)   	|     ✔     	|
-|    [LLC](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/LLC)   	|     ✔     	|
-|    [IKE](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/IKE)   	|     ✔     	|
-|    [HTTP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/HTTP)   |     ✔     	|
-|    [BOOTP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/BOOTP) |     ✔     	|
-|    [DHCP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/DHCP)   |     ✔     	|
+| [ETH](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/Eth)   	    |     ✔     	|
+| [ARP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/ARP)   	    |     ✔     	|
+| [IP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/IP)    	    |     ✔     	|
+| [IPv6](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/IPv6)      |     ✔     	|
+| [TCP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/TCP)   	    |     ✔     	|
+| [UDP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/UDP)   	    |     ✔     	|
+| [ICMP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/ICMP)   	  |     ✔     	|
+| [ICMPv6](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/ICMPv6)  |     ✔     	|
+| [DNS](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/DNS)   	    |     ✔     	|
+| [Dot11](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/Dot11)    |     ✔     	|
+| [Dot1q](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/Dot1q)    |     ✔     	|
+| [EAP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/EAP)   	    |     ✔      	|
+| [ESP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/ESP)   	    |     ✔     	|
+| [GRE](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/GRE)   	    |     ✔     	|
+| [LLC](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/LLC)   	    |     ✔     	|
+| [IKE](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/IKE)   	    |     ✔     	|
+| [HTTP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/HTTP)      |     ✔     	|
+| [BOOTP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/BOOTP)    |     ✔     	|
+| [DHCP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/DHCP)      |     ✔     	|
 
 ##### Table Legend
 | Symbol 	|    Description  	|

--- a/Supported-Protocols.md
+++ b/Supported-Protocols.md
@@ -25,4 +25,7 @@ Here is a list of supported protocol
 |    [GRE](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/GRE)   	|     ✔     	|
 |    [LLC](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/LLC)   	|     ✔     	|
 |    [IKE](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/IKE)   	|     ✔     	|
+|    [HTTP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/HTTP)   	|     ✔     	|
+|    [BOOTP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/BOOTP)   	|     ✔     	|
+|    [DHCP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/DHCP)   	|     ✔     	|
 |          	|              	|

--- a/Supported-Protocols.md
+++ b/Supported-Protocols.md
@@ -1,31 +1,34 @@
-Here is a list of supported protocol 
+# Supported Protocols
 
-| Symbol 	|       Description  	|
-|:--------:	|:-----------------:	|
-|    ✔   	|     Supported     	|
-|    ❗     	| Under development     |
-|    ❌   	|     Supported     	|
+PacketGen provides built-in packet parsers for the following protocols:
 
-
+### Protocols
 | Protocol 	|       Status      	|
 |:--------:	|:-----------------:	|
 |    [ETH](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/Eth)   	|     ✔     	|
 |    [ARP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/ARP)   	|     ✔     	|
-|    [IP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/IP)    	|     ✔     	|
+|    [IP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/IP)    	  |     ✔     	|
 |    [IP6](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/IPv6)   	|     ✔     	|
 |    [TCP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/TCP)   	|     ✔     	|
 |    [UDP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/UDP)   	|     ✔     	|
 |   [ICMP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/ICMP)   	|     ✔     	|
-|   [ICMP6](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/ICMPv6)  	|     ✔     	|
+|   [ICMP6](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/ICMPv6) |     ✔     	|
 |    [DNS](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/DNS)   	|     ✔     	|
-|   [Dot11](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/Dot11)  	|     ✔     	|
-|   [Dot1q](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/Dot1q)  	|     ✔     	|
+|   [Dot11](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/Dot11)  |     ✔     	|
+|   [Dot1q](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/Dot1q)  |     ✔     	|
 |    [EAP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/EAP)   	|     ✔      	|
 |    [ESP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/ESP)   	|     ✔     	|
 |    [GRE](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/GRE)   	|     ✔     	|
 |    [LLC](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/LLC)   	|     ✔     	|
 |    [IKE](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/IKE)   	|     ✔     	|
-|    [HTTP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/HTTP)   	|     ✔     	|
-|    [BOOTP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/BOOTP)   	|     ✔     	|
-|    [DHCP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/DHCP)   	|     ✔     	|
-|          	|              	|
+|    [HTTP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/HTTP)   |     ✔     	|
+|    [BOOTP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/BOOTP) |     ✔     	|
+|    [DHCP](http://www.rubydoc.info/gems/packetgen/PacketGen/Header/DHCP)   |     ✔     	|
+
+##### Table Legend
+| Symbol 	|    Description  	|
+|:-------:|:-----------------:|
+|    ✔   	|     Supported     |
+|    ❗    | Under development |
+|    ❌   	|   Not Supported   |
+


### PR DESCRIPTION
Upon the merging of https://github.com/sdaubert/packetgen/pull/65 and https://github.com/sdaubert/packetgen/pull/66 -- the **Supported Protocols** could use a little update.

This PR aims to be merged when there's a new version bump and release with the new changes. 👍 

* Adds 3 new protocols: HTTP, BOOTP and DHCP.
* Formatting change, placing table legend at the bottom.
* Fix the *Not Supported* legend part.
* Added some simple header texts.
